### PR TITLE
(feat) Add practice view before having access to session view

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -6,6 +6,7 @@ import MainLayout from './main-layout/MainLayout.jsx';
 import HomeView from './home-view/HomeView.jsx';
 import SetupView from './setup-view/SetupView.jsx'; 
 import RecordView from './record-view/RecordView.jsx';
+import PracticeView from './practice-view/PracticeView.jsx';
 import SessionsView from './sessions-view/SessionsView.jsx';
 import ReportView from './report-view/ReportView.jsx';
 import SettingsView from './settings-view/SettingsView.jsx';
@@ -21,8 +22,10 @@ export default class App extends React.Component {
         <Route path="/" component={MainLayout}>
           <IndexRoute component={HomeView} />
           <Route path="setup" component={SetupView} />
-          <Route path="record/:practiceId" component={RecordView} />
-          <Route path="sessions" component={SessionsView} />
+          <Route path="record" component={RecordView} />
+          <Route path="practices" component={PracticeView}>
+            <Route path="sessions" component={SessionsView} />
+          </Route>
           <Route path="reports/:sessionId" component={ReportView} />
           <Route path="settings" component={SettingsView} />
         </Route>

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -6,7 +6,7 @@ import MainLayout from './main-layout/MainLayout.jsx';
 import HomeView from './home-view/HomeView.jsx';
 import SetupView from './setup-view/SetupView.jsx'; 
 import RecordView from './record-view/RecordView.jsx';
-import PracticeView from './practice-view/PracticeView.jsx';
+import PracticesView from './practice-view/PracticesView.jsx';
 import SessionsView from './sessions-view/SessionsView.jsx';
 import ReportView from './report-view/ReportView.jsx';
 import SettingsView from './settings-view/SettingsView.jsx';
@@ -23,7 +23,7 @@ export default class App extends React.Component {
           <IndexRoute component={HomeView} />
           <Route path="setup" component={SetupView} />
           <Route path="record" component={RecordView} />
-          <Route path="practices" component={PracticeView}>
+          <Route path="practices" component={PracticesView}>
             <Route path="sessions" component={SessionsView} />
           </Route>
           <Route path="reports/:sessionId" component={ReportView} />

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -24,7 +24,7 @@ export default class App extends React.Component {
           <Route path="setup" component={SetupView} />
           <Route path="record" component={RecordView} />
           <Route path="practices" component={PracticesView}>
-            <Route path="sessions" component={SessionsView} />
+            <Route path="sessions/:practiceId" component={SessionsView} />
           </Route>
           <Route path="reports/:sessionId" component={ReportView} />
           <Route path="settings" component={SettingsView} />

--- a/client/components/home-view/HomeView.jsx
+++ b/client/components/home-view/HomeView.jsx
@@ -34,7 +34,7 @@ export default class HomeView extends React.Component {
         <div className="home-view-message">Hello, <span ref="firstName"></span>.</div>
         <h4 className="home-view-welcome">Welcome to masterfully.</h4>
         <div className="home-view-instruction">To begin a new video session, click on <span className="instruction-highlight"><Link to="/record">Record</Link></span>.</div>
-        <div className="home-view-instruction">To see reports for all past practices, click on <span className="instruction-highlight"><Link to="/practices">Practices</Link></span>.</div>
+        <div className="home-view-instruction">To see records of all past practices, click on <span className="instruction-highlight"><Link to="/practices">Practices</Link></span>.</div>
         <div className="home-view-instruction"></div>
       </div>
     )

--- a/client/components/home-view/HomeView.jsx
+++ b/client/components/home-view/HomeView.jsx
@@ -34,7 +34,7 @@ export default class HomeView extends React.Component {
         <div className="home-view-message">Hello, <span ref="firstName"></span>.</div>
         <h4 className="home-view-welcome">Welcome to masterfully.</h4>
         <div className="home-view-instruction">To begin a new video session, click on <span className="instruction-highlight"><Link to="/record">Record</Link></span>.</div>
-        <div className="home-view-instruction">To see reports for all past sessions, click on <span className="instruction-highlight"><Link to="/sessions">Sessions</Link></span>.</div>
+        <div className="home-view-instruction">To see reports for all past practices, click on <span className="instruction-highlight"><Link to="/practices">Practices</Link></span>.</div>
         <div className="home-view-instruction"></div>
       </div>
     )

--- a/client/components/practice-view/PracticesView.jsx
+++ b/client/components/practice-view/PracticesView.jsx
@@ -52,7 +52,7 @@ export default class PracticeView extends React.Component {
   }
 
   _showAllSessions(e) { // potentially will have to bind this on line 40
-    console.log("HERE HERE HERE HEAR HERE!", e.target.value);
+    // console.log("HERE HERE HERE HEAR HERE!", e.target.value);
     browserHistory.push('/practices/sessions/' + this.state.practiceHashTable[e.target.value].toString());
   }
 

--- a/client/components/practice-view/PracticesView.jsx
+++ b/client/components/practice-view/PracticesView.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import ReactDom from 'react-dom';
+import { browserHistory } from 'react-router';
+import $ from 'jquery';
+
+export default class PracticeView extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      practiceNames: [],
+      practiceHashTable: {} // name: id
+    }
+  }
+
+  componentDidMount() {
+    this._getPractices(function(data) {
+      // this.setState({ practiceNames: data });/******************* CHECK PracticeController in server and API endpoint ***************************/
+    }.bind(this));
+  }
+
+  _getPractices(callback) {
+    $.ajax({
+      method: 'GET',
+      url: '/api/practice', /******************* CHECK PracticeController in server and API endpoint ***************************/
+      dataType: 'json',
+      success: function(data) {
+        callback(data); /******************* CHECK PracticeController in server and API endpoint ***************************/
+      },
+      error: function(error) {
+        console.error('_getPractices Error: ', error);
+      }
+    });
+  }
+
+  _showAllSessions(practiceName) { // potentially will have to bind this on line 40
+    browserHistory.push('/practices/sessions/' + this.state.practiceHashTable[practiceName].toString());
+  }
+
+  render() {
+    return (
+      <select id="Select a practice..." class="pure-input-1-2" onChange="_showAllSessions(this.value)"> 
+        {this.state.practiceNames.map(
+          practice => (
+            <option>{practice}</option>
+          )
+        )}
+      </select>
+      {this.props.children}
+    )
+  }
+}

--- a/client/components/practice-view/PracticesView.jsx
+++ b/client/components/practice-view/PracticesView.jsx
@@ -13,18 +13,23 @@ export default class PracticeView extends React.Component {
   }
 
   componentDidMount() {
-    this._getPractices(function(data) {
-      // this.setState({ practiceNames: data });/******************* CHECK PracticeController in server and API endpoint ***************************/
+    this._getPractices(function (data) {
+      let [practiceNames, practiceHashTable] = this._organizePractices(data);
+
+      this.setState({ 
+        practiceNames: practiceNames,
+        practiceHashTable: practiceHashTable
+      }); 
     }.bind(this));
   }
 
   _getPractices(callback) {
     $.ajax({
       method: 'GET',
-      url: '/api/practice', /******************* CHECK PracticeController in server and API endpoint ***************************/
+      url: '/api/practice',
       dataType: 'json',
       success: function(data) {
-        callback(data); /******************* CHECK PracticeController in server and API endpoint ***************************/
+        callback(data);
       },
       error: function(error) {
         console.error('_getPractices Error: ', error);
@@ -32,20 +37,39 @@ export default class PracticeView extends React.Component {
     });
   }
 
-  _showAllSessions(practiceName) { // potentially will have to bind this on line 40
-    browserHistory.push('/practices/sessions/' + this.state.practiceHashTable[practiceName].toString());
+  _organizePractices(data) {
+    let practiceNames = [];
+    let practiceHashTable = {};
+
+    // loop through the data received from GET request to populate state
+    for (let i=0; i<data.length; i++) {
+      let practice = data[i];
+      practiceNames.push(practice.name);
+      practiceHashTable[practice.name] = practice.id;
+    }
+
+    return [practiceNames, practiceHashTable];
   }
+
+  _showAllSessions(e) { // potentially will have to bind this on line 40
+    console.log("HERE HERE HERE HEAR HERE!", e.target.value);
+    browserHistory.push('/practices/sessions/' + this.state.practiceHashTable[e.target.value].toString());
+  }
+
 
   render() {
     return (
-      <select id="Select a practice..." class="pure-input-1-2" onChange="_showAllSessions(this.value)"> 
-        {this.state.practiceNames.map(
-          practice => (
-            <option>{practice}</option>
-          )
-        )}
-      </select>
-      {this.props.children}
+      <div>
+        <select id="allPractices" class="pure-input-1-2" onChange={this._showAllSessions.bind(this)}> 
+          <option selected disabled>Select a practice...</option>
+          {this.state.practiceNames.map(
+            practice => (
+              <option>{practice}</option>
+            )
+          )}
+        </select>
+        {this.props.children}
+      </div>
     )
   }
 }

--- a/client/components/sessions-view/SessionsView.jsx
+++ b/client/components/sessions-view/SessionsView.jsx
@@ -3,7 +3,7 @@ import SessionEntry from './SessionEntry.jsx';
 import { browserHistory } from 'react-router';
 import $ from 'jquery';
 
-// import dummyData from './../../../data/session-data.json';
+/******************* Use session ID from this.props.params.practiceId ***************************/
 
 export default class SessionsView extends React.Component {
   constructor(props) {
@@ -22,7 +22,7 @@ export default class SessionsView extends React.Component {
   _getSessions(callback) {
     $.ajax({
       method: 'GET',
-      url: '/api/session',
+      url: '/api/session', // specify practice_id in api endpoint
       success: function(data) {
         callback(data);
       },

--- a/client/components/sessions-view/SessionsView.jsx
+++ b/client/components/sessions-view/SessionsView.jsx
@@ -20,9 +20,10 @@ export default class SessionsView extends React.Component {
   }
 
   _getSessions(callback) {
+    var endpoint = '/api/session/' + this.props.params.practiceId;
     $.ajax({
       method: 'GET',
-      url: '/api/session', // specify practice_id in api endpoint
+      url: endpoint,
       success: function(data) {
         callback(data);
       },

--- a/client/components/sessions-view/SessionsView.jsx
+++ b/client/components/sessions-view/SessionsView.jsx
@@ -3,8 +3,6 @@ import SessionEntry from './SessionEntry.jsx';
 import { browserHistory } from 'react-router';
 import $ from 'jquery';
 
-/******************* Use session ID from this.props.params.practiceId ***************************/
-
 export default class SessionsView extends React.Component {
   constructor(props) {
     super(props);
@@ -20,7 +18,8 @@ export default class SessionsView extends React.Component {
   }
 
   _getSessions(callback) {
-    var endpoint = '/api/session/' + this.props.params.practiceId;
+    const endpoint = '/api/session/' + this.props.params.practiceId;
+
     $.ajax({
       method: 'GET',
       url: endpoint,

--- a/server/controllers/PracticeController.js
+++ b/server/controllers/PracticeController.js
@@ -4,27 +4,27 @@ var Question = require('../models/QuestionModel.js');
 
 module.exports = {
   createPractice: function (req, res) {
-    console.log(req.body, 'Req Data in createPractice');
-    var practiceObj = {
+    // console.log(req.body, 'Req Data in createPractice');
+    const practice = {
       user_id: req.user.id,
       name: req.body.title,
       description: req.body.description,
       // subject: req.body.subject, // not currently in DB
     }
 
-    return new Practice(practiceObj).save()
+    return new Practice(practice).save()
       .then(function(newPractice) {
-        req.body.questions.map(function(string) {
-          var questionObj = {
-            question: string,
+        req.body.questions.map(function(questionContent) {
+          const questionObj = {
+            question: questionContent,
             practice_id: newPractice.id
           }
           new Question(questionObj).save()
-            .then(function(data) {
-              console.log('data saved', data); 
+            .then(function(newQuestion) {
+              console.log('Question saved', newQuestion); 
             })
             .catch(function(error) {
-              console.log('question error', error); 
+              console.log('Error saving question: ', error); 
             }); 
         })
         return newPractice; 
@@ -46,7 +46,7 @@ module.exports = {
 
     Practice.where(queryObj).fetchAll()
       .then(function(practices) {
-        // console.log('no error', practices); 
+        console.log('Practices from db, no error', practices); 
         res.status(200).send(practices);
       })
       .catch(function(error) {


### PR DESCRIPTION
### Summary

Now has to navigate through practiceView before having access to sessions
##### Description

-/practice route in react-router replaces /session
-/session is now nested under /practice in react-router
-Create client/components/practice-view/PracticesView.jsx
-PracticeView makes GET request to /api/practice server for all practice names for a given user
-Clicking on practice routes user to client/components/sessions-view/SessionsView.jsx
- SessionsView is populated with all sessions for a given practice of the user
##### Related Issue
#14
#15
##### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Automated Testing
- [ ] Documentation
##### Screenshots (if appropriate)

![screen shot 2016-06-08 at 20 47 05](https://cloud.githubusercontent.com/assets/8594433/15918401/521f9d16-2dbb-11e6-8d21-7f897e0f013a.png)

![screen shot 2016-06-08 at 20 43 32](https://cloud.githubusercontent.com/assets/8594433/15918408/62abb0b6-2dbb-11e6-95b7-1f436e790bc6.png)

![screen shot 2016-06-08 at 20 44 05](https://cloud.githubusercontent.com/assets/8594433/15918414/6e1081ac-2dbb-11e6-8f1c-d21979ddfc94.png)

![screen shot 2016-06-08 at 20 44 13](https://cloud.githubusercontent.com/assets/8594433/15918416/741623ea-2dbb-11e6-92dc-1e602d57cab3.png)

![screen shot 2016-06-08 at 20 44 19](https://cloud.githubusercontent.com/assets/8594433/15918421/78bab686-2dbb-11e6-8340-d8e1b2f97b82.png)
### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
